### PR TITLE
upgrade moditect to 1.0.0.Final: fixes RB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <!-- 04-Mar-2019, latest property with v35, for Java 9+ Modules support 
              (originally added in v34)
      -->
-    <version.plugin.moditect>1.0.0.RC2</version.plugin.moditect>
+    <version.plugin.moditect>1.0.0.Final</version.plugin.moditect>
 
     <version.plugin.release>3.0.0-M7</version.plugin.release>
     <version.plugin.replacer>1.5.3</version.plugin.replacer>


### PR DESCRIPTION
this plugin release was done to fix RB issues like this: https://github.com/moditect/moditect/issues/185

and it's the only missing piece to have RB ok for Jackson projects: see for example https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/com/fasterxml/jackson/annotations/README.md